### PR TITLE
Workflow to create draft .pdf of the paper

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -1,0 +1,23 @@
+on: [push]
+
+jobs:
+  paper:
+    runs-on: ubuntu-latest
+    name: Paper Draft
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build draft PDF
+        uses: openjournals/openjournals-draft-action@master
+        with:
+          journal: joss
+          # This should be the path to the paper within your repo.
+          paper-path: paper/paper.md
+      - name: Upload
+        uses: actions/upload-artifact@v1
+        with:
+          name: paper
+          # This is the output path where Pandoc will write the compiled
+          # PDF. Note, this should be the same directory as the input
+          # paper.md
+          path: paper/paper.pdf


### PR DESCRIPTION
JOSS submission guidelines recommend adding this action to the github to compile the paper https://github.com/marketplace/actions/open-journals-pdf-generator

Worked for me in testing in another private repo. Only issue I saw was the justification of some text but that was the fault of the action which I didn't write and is recommended by JOSS.